### PR TITLE
Fix potential performance issue

### DIFF
--- a/lib/slonik-core.module.ts
+++ b/lib/slonik-core.module.ts
@@ -38,7 +38,7 @@ export class SlonikCoreModule implements OnApplicationShutdown {
   static forRoot(options: SlonikModuleOptions): DynamicModule {
     const slonikOptions = {
       provide: SLONIK_MODULE_OPTIONS,
-      useValue: options,
+      useFactory: () => options,
     };
     const poolProvider = {
       provide: getPoolToken(options),


### PR DESCRIPTION
In https://github.com/nestjs/nest/issues/12738, a potential issue has been identified where if a huge object is passed to useValue, NestJS will spend a lot of time serializing that object.
 
Use useFactory instead of useValue to avoid this issue.

Testing locally on a beefy MBP M1, this reduced my initialization time from 1.03ms to 0.01ms.